### PR TITLE
feat/ci: bump actions/setup-go to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
 
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,6 +18,7 @@ jobs:
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/differ:main .
 
     - name: Publish image
+      if: github.repository == 'vanilla-os/differ' && github.ref == 'refs/heads/main'
       run: |
         docker login ghcr.io -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }}
         docker image push "ghcr.io/vanilla-os/differ:main"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,7 +18,7 @@ jobs:
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/differ:main .
 
     - name: Publish image
-      if: github.repository == 'vanilla-os/differ' && github.ref == 'refs/heads/main'
+      if: github.repository == 'Vanilla-OS/differ' && github.ref == 'refs/heads/main'
       run: |
         docker login ghcr.io -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }}
         docker image push "ghcr.io/vanilla-os/differ:main"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,7 +18,7 @@ jobs:
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/differ:main .
 
     - name: Publish image
-      if: github.repository == 'Vanilla-OS/differ' && github.ref == 'refs/heads/main'
+      if: github.repository == 'Vanilla-OS/Differ' && github.ref == 'refs/heads/main'
       run: |
         docker login ghcr.io -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }}
         docker image push "ghcr.io/vanilla-os/differ:main"


### PR DESCRIPTION
## Changes

- Bump `actions/setup-go` to `v5` (Node 20).
- Set the publish image job's ref head to not run on forks (this allows us to test building images, without worrying about the failing publish action).