### PR TITLE
feat: Upgrade image build process for multi-architecture support

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,11 +14,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build image
-      run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/differ:main .
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-    - name: Publish image
-      if: github.repository == 'Vanilla-OS/Differ' && github.ref == 'refs/heads/main'
-      run: |
-        docker login ghcr.io -u ${{ env.REGISTRY_USER }} -p ${{ env.REGISTRY_PASSWORD }}
-        docker image push "ghcr.io/vanilla-os/differ:main"
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+    
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        provenance: false
+        context: .
+        file: Containerfile
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.repository == 'simon511000/Differ' && github.ref == 'refs/heads/main' }}
+        tags: ghcr.io/simon511000/differ:main

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -34,5 +34,5 @@ jobs:
         context: .
         file: Containerfile
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.repository == 'simon511000/Differ' && github.ref == 'refs/heads/main' }}
-        tags: ghcr.io/simon511000/differ:main
+        push: ${{ github.repository == 'Vanilla-OS/Differ' && github.ref == 'refs/heads/main' }}
+        tags: ghcr.io/vanilla-os/differ:main


### PR DESCRIPTION
To make my Differ instance work on my Raspberry Pi, I have to build the image manually. This pull request enables the use of docker buildx to build the image for both amd64 and arm64 architectures.

Note:
Github Actions is very slow for building multi-arch images, the image workflow goes from 2 minutes to [12 minutes](https://github.com/simon511000/Differ/actions/runs/7784289505).